### PR TITLE
disable UIToolbarContentView every time one is created in layoutSubviews

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -117,16 +117,10 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 {
     [super layoutSubviews];
     
-    static BOOL toolbarContentViewEnabled = YES;
+    UIView *lastView = [self.subviews lastObject];
     
-    if (toolbarContentViewEnabled) {
-        for (id view in self.subviews) {
-            if ([view isKindOfClass:(NSClassFromString(@"_UIToolbarContentView"))]) {
-                UIView *toolbarContentView = view;
-                toolbarContentView.userInteractionEnabled = NO;
-            }
-        }
-        toolbarContentViewEnabled = NO;
+    if ([lastView isKindOfClass:(NSClassFromString(@"_UIToolbarContentView"))]) {
+        lastView.userInteractionEnabled = NO;
     }
 }
 

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -117,10 +117,12 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 {
     [super layoutSubviews];
     
-    UIView *lastView = [self.subviews lastObject];
-    
-    if ([lastView isKindOfClass:(NSClassFromString(@"_UIToolbarContentView"))]) {
-        lastView.userInteractionEnabled = NO;
+    for (id view in [self.subviews reverseObjectEnumerator]) {
+        if ([view isKindOfClass:(NSClassFromString(@"_UIToolbarContentView"))]) {
+            UIView *toolbarContentView = view;
+            toolbarContentView.userInteractionEnabled = NO;
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
A new UIToolbarContentView is added during layoutSubviews each time. When users reload the view, the newly created UIToolbarContentView requires disabling again. This pull request takes away the local static variable toolbarContentViewEnabled, since a check is required each time. It also only checks if the last subview is of class _UIToolbarContentView since the UIToolbarContentView is always added last.